### PR TITLE
Migrate references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ There are 2 (two) ways to use Memento Damage tool in local machine: using Docker
 ### Docker
 First, install docker in your machine, and make sure docker daemon is started. Please refer to this steps on how to install docker: https://docs.docker.com/engine/getstarted/step_one/#step-2-install-docker. 
 
-Pull the docker image of memento-damage from: erikaris/memento-damage:
+Pull the docker image of memento-damage from: oduwsdl/memento-damage:
 ```
-docker pull erikaris/memento-damage
+docker pull oduwsdl/memento-damage
 ```
 
 Run the container for the image:
 ```
-docker run -i -t -P --name memento-damage erikaris/memento-damage:latest /app/entrypoint.sh
+docker run -i -t -P --name memento-damage oduwsdl/memento-damage:latest /app/entrypoint.sh
 
 ```
 Then, user can start executing memento-damage tool from within docker container or outside docker container.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ There are 2 ways to use this tool:
 ### Website
 The website version can be used by accesing http://memento-damage.cs.odu.edu/. This service is suitable for the purpose of finding the damage of single URI. To use the tool, user just simply type or paste the URI to the damage-check textbox form, and type enter or click check button.
 
-![](https://github.com/erikaris/web-memento-damage/raw/screenshot/pasted%20image%200.png)
+![](https://github.com/oduwsdl/web-memento-damage/raw/screenshot/pasted%20image%200.png)
 
 The output will be displayed on the result page, on tab ‘summary’. Other tabs in the result page provide the details of the damage according to the resources types: images, stylesheets, javascript, multimedia, and text. Tab ‘screenshot’ provide the screenshot of the URI and tab ‘log’ gives the details of the process that happens during the damage calculation.
 
-![](https://github.com/erikaris/web-memento-damage/raw/screenshot/online-2.png)
+![](https://github.com/oduwsdl/web-memento-damage/raw/screenshot/online-2.png)
 
 ### REST API
 REST API facilitates damage calculation from any HTTP Client (e.g. web browser, curl, etc) and give output in JSON format. This enables user to do further analysis with the output. User can create a script and utilize the REST API to calculate damage on few number of URIs (e.g. 5). Here are some simple examples of accessing memento-damage service using REST API:
@@ -85,7 +85,7 @@ docker exec memento-damage memento-damage [options] <URI>
 
 ### Library
 Using library is relatively similar to using docker. The installation process is much simpler and faster than the docker version. But user has to ensure that all the requirements (phantomjs 2.xx and python 2.7) are installed on their machines.  <br />
-Download the latest library version from https://github.com/erikaris/web-memento-damage/tree/master/dist. <br />
+Download the latest library version from https://github.com/oduwsdl/web-memento-damage/tree/master/dist. <br />
 Install the library using command:  
 ```
 sudo pip install memento-damage-x.x.x.tar.gz

--- a/memento_damage/web/modules/mod_contact_us/views/contact_us_index.html
+++ b/memento_damage/web/modules/mod_contact_us/views/contact_us_index.html
@@ -35,7 +35,7 @@
             <hr/>
 
             <h4><i class="fa fa-github"></i>&nbsp;Github</h4>
-            <p><a href="https://github.com/erikaris/web-memento-damage.git">https://github.com/erikaris/web-memento-damage.git</a></p>
+            <p><a href="https://github.com/oduwsdl/web-memento-damage.git">https://github.com/oduwsdl/web-memento-damage.git</a></p>
 
           </div>
         </div>
@@ -43,7 +43,7 @@
           <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3191.2004999347914!2d-76.30895628513238!3d36.88555147993098!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89ba99ad24ba3945%3A0xcd2bdc432c4e4bac!2sOld+Dominion+University!5e0!3m2!1sen!2sid!4v1490057383475" frameborder="0" style="border:0; padding:0" class="border" allowfullscreen></iframe>
         </div>
 
-        <!--<p> Should you find any problem or error, feel free to contact us by opening an issue on github: <a href="https://github.com/erikaris/web-memento-damage/issues" target="_blank">  https://github.com/erikaris/web-memento-damage/issues </a>. </p>-->
+        <!--<p> Should you find any problem or error, feel free to contact us by opening an issue on github: <a href="https://github.com/oduwsdl/web-memento-damage/issues" target="_blank">  https://github.com/oduwsdl/web-memento-damage/issues </a>. </p>-->
       </div>
     </div>
 

--- a/memento_damage/web/modules/mod_faq/views/faq_index.html
+++ b/memento_damage/web/modules/mod_faq/views/faq_index.html
@@ -50,7 +50,7 @@
               <h3>Is it free to use?</h3>
             </div>
             <div class="widget-content">
-              <p>Yes, it is free and open source. The source code is availabe on github: <a href="https://github.com/erikaris/web-memento-damage">https://github.com/erikaris/web-memento-damage</a></p>
+              <p>Yes, it is free and open source. The source code is availabe on github: <a href="https://github.com/oduwsdl/web-memento-damage">https://github.com/oduwsdl/web-memento-damage</a></p>
             </div>
           </div>
 

--- a/memento_damage/web/modules/mod_help/views/help_index.html
+++ b/memento_damage/web/modules/mod_help/views/help_index.html
@@ -74,11 +74,11 @@ print resp.json()
           <p>There are 2 (two) ways to use Memento Damage tool in local machine: using Docker or library. Using docker is recommended since user does not need to worry about system dependencies.</p>
           <h3><a id="Docker_42"></a>Docker</h3>
           <p>First, install docker in your machine, and make sure docker daemon is started. Please refer to this steps on how to install docker: <a href="https://docs.docker.com/engine/getstarted/step_one/#step-2-install-docker">https://docs.docker.com/engine/getstarted/step_one/#step-2-install-docker</a>.</p>
-          <p>Pull the docker image of memento-damage from: erikaris/memento-damage:</p>
-          <pre><code>docker pull erikaris/memento-damage
+          <p>Pull the docker image of memento-damage from: oduwsdl/memento-damage:</p>
+          <pre><code>docker pull oduwsdl/memento-damage
           </code></pre>
           <p>Run the container for the image:</p>
-          <pre><code>docker run -i -t -P --name memento-damage erikaris/memento-damage:latest /app/entrypoint.sh
+          <pre><code>docker run -i -t -P --name memento-damage oduwsdl/memento-damage:latest /app/entrypoint.sh
 
           </code></pre>
           <p>Then, user can start executing memento-damage tool from within docker container or outside docker container.</p>

--- a/memento_damage/web/modules/mod_help/views/help_index.html
+++ b/memento_damage/web/modules/mod_help/views/help_index.html
@@ -56,9 +56,9 @@
           <h2><a id="Online_Service_11"></a>Online Service</h2>
           <h3><a id="Website_12"></a>Website</h3>
           <p>The website version can be used by accesing <a href="http://memento-damage.cs.odu.edu/">http://memento-damage.cs.odu.edu/</a>. This service is suitable for the purpose of finding the damage of single URI. To use the tool, user just simply type or paste the URI to the damage-check textbox form, and type enter or click check button.</p>
-          <p><img src="https://github.com/erikaris/web-memento-damage/raw/screenshot/pasted%20image%200.png" alt="" style="width: 100%;"></p>
+          <p><img src="https://github.com/oduwsdl/web-memento-damage/raw/screenshot/pasted%20image%200.png" alt="" style="width: 100%;"></p>
           <p>The output will be displayed on the result page, on tab ‘summary’. Other tabs in the result page provide the details of the damage according to the resources types: images, stylesheets, javascript, multimedia, and text. Tab ‘screenshot’ provide the screenshot of the URI and tab ‘log’ gives the details of the process that happens during the damage calculation.</p>
-          <p><img src="https://github.com/erikaris/web-memento-damage/raw/screenshot/online-2.png" alt="" style="width: 100%;"></p>
+          <p><img src="https://github.com/oduwsdl/web-memento-damage/raw/screenshot/online-2.png" alt="" style="width: 100%;"></p>
           <h3><a id="REST_API_21"></a>REST API</h3>
           <p>REST API facilitates damage calculation from any HTTP Client (e.g. web browser, curl, etc) and give output in JSON format. This enables user to do further analysis with the output. User can create a script and utilize the REST API to calculate damage on few number of URIs (e.g. 5). Here are some simple examples of accessing memento-damage service using REST API:</p>
           <h4><a id="CURL_25"></a>CURL</h4>
@@ -101,7 +101,7 @@ print resp.json()
           </code></pre>
           <h3><a id="Library_83"></a>Library</h3>
           <p>Using library is relatively similar to using docker. The installation process is much simpler and faster than the docker version. But user has to ensure that all the requirements (phantomjs 2.xx and python 2.7) are installed on their machines.</p>
-          <p>Download the latest library version from <a href="https://github.com/erikaris/web-memento-damage/tree/master/dist">https://github.com/erikaris/web-memento-damage/tree/master/dist</a>.</p>
+          <p>Download the latest library version from <a href="https://github.com/oduwsdl/web-memento-damage/tree/master/dist">https://github.com/oduwsdl/web-memento-damage/tree/master/dist</a>.</p>
           <p>Install the library using command:</p>
           <pre><code>sudo pip install memento-damage-x.x.x.tar.gz
           </code></pre>

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'flask',
         'Flask-SQLAlchemy'
     ],
-    url='https://github.com/erikaris/web-memento-damage',
+    url='https://github.com/oduwsdl/web-memento-damage',
     license='',
     author='erikaris',
     author_email='erikaris1515@gmail.com',


### PR DESCRIPTION
The repo was migrated from `erikaris` to `oduwsdl` a while ago, but references in the documentation remained the old ones.